### PR TITLE
Bump ahash dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde-amortized = [ "serde", "amortized", "griddle/serde" ]
 inline-more-amortized = [ "inline-more", "amortized", "griddle/inline-more" ]
 
 [dependencies]
-ahash_ = { version = "0.7", default-features = false, optional = true, package = "ahash" }
+ahash_ = { version = "0.8.5", default-features = false, optional = true, package = "ahash" }
 hashbrown = { version = "0.11", default-features = false }
 griddle = { version = "0.5.1", default-features = false, optional = true }
 serde_ = { version = "1.0", default-features = false, optional = true, package = "serde" }


### PR DESCRIPTION
The previous version had a bug, and was yanked.